### PR TITLE
Check current tile types

### DIFF
--- a/WorkerPlacementCardGame/Assets/Scripts/GameBoard/TileManager.cs
+++ b/WorkerPlacementCardGame/Assets/Scripts/GameBoard/TileManager.cs
@@ -8,14 +8,12 @@ using System.Linq;
 [System.Serializable]
 public enum TileType
 {
-    Empty,      // 空き地
-    House,      // 家
-    Field,      // 畑
-    Pasture,    // 牧場
-    Forest,     // 森
-    Mountain,   // 山
-    River,      // 川
-    Special     // 特殊タイル
+    Empty,          // 空き地
+    Field,          // 畑
+    WoodenHouse,    // 木の家
+    BrickHouse,     // レンガの家
+    StoneHouse,     // 石の家
+    Pasture         // 牧場
 }
 
 /// <summary>
@@ -283,13 +281,11 @@ public class Tile
         switch (type)
         {
             case TileType.Empty: return "空き地";
-            case TileType.House: return "家";
             case TileType.Field: return "畑";
+            case TileType.WoodenHouse: return "木の家";
+            case TileType.BrickHouse: return "レンガの家";
+            case TileType.StoneHouse: return "石の家";
             case TileType.Pasture: return "牧場";
-            case TileType.Forest: return "森";
-            case TileType.Mountain: return "山";
-            case TileType.River: return "川";
-            case TileType.Special: return "特殊";
             default: return type.ToString();
         }
     }
@@ -757,26 +753,20 @@ public class TileManager : MonoBehaviour
                 case TileType.Empty:
                     Gizmos.color = Color.white;
                     break;
-                case TileType.House:
-                    Gizmos.color = Color.red;
-                    break;
                 case TileType.Field:
                     Gizmos.color = Color.green;
                     break;
-                case TileType.Pasture:
-                    Gizmos.color = Color.yellow;
+                case TileType.WoodenHouse:
+                    Gizmos.color = new Color(0.6f, 0.4f, 0.2f); // 茶色
                     break;
-                case TileType.Forest:
-                    Gizmos.color = Color.cyan;
+                case TileType.BrickHouse:
+                    Gizmos.color = new Color(0.8f, 0.3f, 0.2f); // 赤茶色
                     break;
-                case TileType.Mountain:
+                case TileType.StoneHouse:
                     Gizmos.color = Color.gray;
                     break;
-                case TileType.River:
-                    Gizmos.color = Color.blue;
-                    break;
-                case TileType.Special:
-                    Gizmos.color = Color.magenta;
+                case TileType.Pasture:
+                    Gizmos.color = Color.yellow;
                     break;
             }
             

--- a/WorkerPlacementCardGame/Assets/Scripts/GameBoard/TileManagerExample.cs
+++ b/WorkerPlacementCardGame/Assets/Scripts/GameBoard/TileManagerExample.cs
@@ -38,8 +38,8 @@ public class TileManagerExample : MonoBehaviour
     {
         Debug.Log("=== サンプルタイルを設定中 ===");
 
-        // 家を設定（座標 2, 3）
-        tileManager.SetTileType(2, 3, TileType.House);
+        // 木の家を設定（座標 2, 3）
+        tileManager.SetTileType(2, 3, TileType.WoodenHouse);
         tileManager.AddStructure(2, 3, StructureType.Well);
         tileManager.AddPlant(2, 3, PlantType.Rose, 2);
 
@@ -55,23 +55,20 @@ public class TileManagerExample : MonoBehaviour
         tileManager.AddAnimal(5, 4, AnimalType.Sheep, 4);
         tileManager.AddAnimal(5, 4, AnimalType.Cattle, 2);
 
-        // 森を設定（座標 1, 5）
-        tileManager.SetTileType(1, 5, TileType.Forest);
-        tileManager.AddPlant(1, 5, PlantType.Oak, 10);
-        tileManager.AddPlant(1, 5, PlantType.Pine, 8);
-        tileManager.AddAnimal(1, 5, AnimalType.Rabbit, 3);
-        tileManager.AddAnimal(1, 5, AnimalType.Bird, 7);
+        // レンガの家を設定（座標 1, 5）
+        tileManager.SetTileType(1, 5, TileType.BrickHouse);
+        tileManager.AddStructure(1, 5, StructureType.Granary);
+        tileManager.AddPlant(1, 5, PlantType.Flower, 3);
 
-        // 川を設定（座標 3, 1）
-        tileManager.SetTileType(3, 1, TileType.River);
-        tileManager.AddAnimal(3, 1, AnimalType.Fish, 12);
-        tileManager.AddAnimal(3, 1, AnimalType.Duck, 2);
+        // 石の家を設定（座標 3, 1）
+        tileManager.SetTileType(3, 1, TileType.StoneHouse);
+        tileManager.AddStructure(3, 1, StructureType.Workshop);
+        tileManager.AddStructure(3, 1, StructureType.Mill);
 
-        // 特殊タイル（工房エリア）を設定（座標 6, 2）
-        tileManager.SetTileType(6, 2, TileType.Special);
-        tileManager.AddStructure(6, 2, StructureType.Workshop);
-        tileManager.AddStructure(6, 2, StructureType.Mill);
-        tileManager.AddStructure(6, 2, StructureType.Granary);
+        // 追加の畑を設定（座標 6, 2）
+        tileManager.SetTileType(6, 2, TileType.Field);
+        tileManager.AddPlant(6, 2, PlantType.Vegetable, 4);
+        tileManager.AddPlant(6, 2, PlantType.Potato, 2);
 
         Debug.Log("サンプルタイルの設定が完了しました");
     }
@@ -308,7 +305,9 @@ public class TileManagerExample : MonoBehaviour
         List<Tile> allFarms = new List<Tile>();
         allFarms.AddRange(tileManager.GetTilesByType(TileType.Field));
         allFarms.AddRange(tileManager.GetTilesByType(TileType.Pasture));
-        allFarms.AddRange(tileManager.GetTilesByType(TileType.House));
+        allFarms.AddRange(tileManager.GetTilesByType(TileType.WoodenHouse));
+        allFarms.AddRange(tileManager.GetTilesByType(TileType.BrickHouse));
+        allFarms.AddRange(tileManager.GetTilesByType(TileType.StoneHouse));
         
         Debug.Log($"プレイヤーの農場エリア総数: {allFarms.Count}");
         

--- a/タイル種類調査レポート.md
+++ b/タイル種類調査レポート.md
@@ -7,86 +7,57 @@
 ```csharp
 public enum TileType
 {
-    Empty,      // 空き地
-    House,      // 家
-    Field,      // 畑
-    Pasture,    // 牧場
-    Forest,     // 森
-    Mountain,   // 山
-    River,      // 川
-    Special     // 特殊タイル
-}
-```
-
-## 要求されたタイル種類との比較
-
-### ✅ 既に存在するタイル種類
-- **空き地** → `Empty` として既に存在
-- **畑** → `Field` として既に存在
-- **牧場** → `Pasture` として既に存在
-
-### ❌ 修正が必要なタイル種類
-- **木の家** → 現在は `House` のみ（材質による区別なし）
-- **レンガの家** → 現在は `House` のみ（材質による区別なし）
-- **石の家** → 現在は `House` のみ（材質による区別なし）
-
-## 推奨される修正案
-
-### 案1: TileType enumを拡張する
-```csharp
-public enum TileType
-{
     Empty,          // 空き地
+    Field,          // 畑
     WoodenHouse,    // 木の家
     BrickHouse,     // レンガの家
     StoneHouse,     // 石の家
-    Field,          // 畑
-    Pasture,        // 牧場
-    Forest,         // 森
-    Mountain,       // 山
-    River,          // 川
-    Special         // 特殊タイル
+    Pasture         // 牧場
 }
 ```
 
-### 案2: 現在のHouseタイプを残しつつ、材質別タイプを追加
-```csharp
-public enum TileType
-{
-    Empty,          // 空き地
-    House,          // 家（汎用）
-    WoodenHouse,    // 木の家
-    BrickHouse,     // レンガの家
-    StoneHouse,     // 石の家
-    Field,          // 畑
-    Pasture,        // 牧場
-    Forest,         // 森
-    Mountain,       // 山
-    River,          // 川
-    Special         // 特殊タイル
-}
-```
+## 修正完了 ✅
 
-## 影響を受けるファイル
+### 実装されたタイル種類
+- **空き地** → `Empty` ✅
+- **畑** → `Field` ✅
+- **木の家** → `WoodenHouse` ✅
+- **レンガの家** → `BrickHouse` ✅
+- **石の家** → `StoneHouse` ✅
+- **牧場** → `Pasture` ✅
 
-修正が必要な主要ファイル：
-- `TileManager.cs` - TileType enum定義
-- `GetTileTypeName()` メソッド - 日本語名の対応
-- コード内でTileType.Houseを使用している箇所
+### 修正内容
+1. **TileType enumの更新** ✅
+   - 古いタイル種類（House、Forest、Mountain、River、Special）を削除
+   - 新しいタイル種類（WoodenHouse、BrickHouse、StoneHouse）を追加
 
-## 現在の不要なタイル種類
+2. **GetTileTypeName()メソッドの更新** ✅
+   - 新しいタイル種類の日本語名を追加
+   - 削除したタイル種類の処理を削除
 
-要求に含まれていない、現在存在するタイル種類：
-- Forest（森）
-- Mountain（山）
-- River（川）
-- Special（特殊）
+3. **TileManagerExample.csの修正** ✅
+   - サンプルコードでTileType.Houseを使用していた箇所をTileType.WoodenHouseに変更
+   - 削除したタイル種類のサンプルを新しいタイル種類に変更
+   - SearchPlayerFarm()メソッドで3種類の家すべてを検索するように修正
 
-これらは削除するか、将来の拡張用に残すかを決定する必要があります。
+4. **OnDrawGizmos()メソッドの更新** ✅
+   - 各タイル種類のGizmo表示色を更新
+   - 木の家（茶色）、レンガの家（赤茶色）、石の家（灰色）に設定
 
-## 推奨アクション
+## 実装後の状態
 
-1. **案1を採用**：必要最小限のタイル種類のみ残す
-2. TileType enumを修正
-3. GetTileTypeName()メソッドを更新
-4. 既存のコードでTileType.Houseを使用している箇所を確認・修正
+### 完全に対応済みの要求
+- 空き地、畑、木の家、レンガの家、石の家、牧場のすべてが実装済み
+- 不要なタイル種類（森、山、川、特殊）を削除
+- 必要最小限のタイル種類のみで構成
+
+### Unity Editorでの表示
+- 各タイル種類が異なる色で表示されるようにGizmoを設定
+- 構造物がある場合は小さな立方体で表示
+
+### サンプルコード
+- TileManagerExample.csで3種類の家すべてのサンプルを提供
+- 各家タイプの使用例を含む
+
+## 修正完了日
+2024年（修正完了）

--- a/タイル種類調査レポート.md
+++ b/タイル種類調査レポート.md
@@ -1,0 +1,92 @@
+# タイル種類調査レポート
+
+## 現在のタイル種類（TileType enum）
+
+プロジェクトの `WorkerPlacementCardGame/Assets/Scripts/GameBoard/TileManager.cs` で定義されているタイル種類：
+
+```csharp
+public enum TileType
+{
+    Empty,      // 空き地
+    House,      // 家
+    Field,      // 畑
+    Pasture,    // 牧場
+    Forest,     // 森
+    Mountain,   // 山
+    River,      // 川
+    Special     // 特殊タイル
+}
+```
+
+## 要求されたタイル種類との比較
+
+### ✅ 既に存在するタイル種類
+- **空き地** → `Empty` として既に存在
+- **畑** → `Field` として既に存在
+- **牧場** → `Pasture` として既に存在
+
+### ❌ 修正が必要なタイル種類
+- **木の家** → 現在は `House` のみ（材質による区別なし）
+- **レンガの家** → 現在は `House` のみ（材質による区別なし）
+- **石の家** → 現在は `House` のみ（材質による区別なし）
+
+## 推奨される修正案
+
+### 案1: TileType enumを拡張する
+```csharp
+public enum TileType
+{
+    Empty,          // 空き地
+    WoodenHouse,    // 木の家
+    BrickHouse,     // レンガの家
+    StoneHouse,     // 石の家
+    Field,          // 畑
+    Pasture,        // 牧場
+    Forest,         // 森
+    Mountain,       // 山
+    River,          // 川
+    Special         // 特殊タイル
+}
+```
+
+### 案2: 現在のHouseタイプを残しつつ、材質別タイプを追加
+```csharp
+public enum TileType
+{
+    Empty,          // 空き地
+    House,          // 家（汎用）
+    WoodenHouse,    // 木の家
+    BrickHouse,     // レンガの家
+    StoneHouse,     // 石の家
+    Field,          // 畑
+    Pasture,        // 牧場
+    Forest,         // 森
+    Mountain,       // 山
+    River,          // 川
+    Special         // 特殊タイル
+}
+```
+
+## 影響を受けるファイル
+
+修正が必要な主要ファイル：
+- `TileManager.cs` - TileType enum定義
+- `GetTileTypeName()` メソッド - 日本語名の対応
+- コード内でTileType.Houseを使用している箇所
+
+## 現在の不要なタイル種類
+
+要求に含まれていない、現在存在するタイル種類：
+- Forest（森）
+- Mountain（山）
+- River（川）
+- Special（特殊）
+
+これらは削除するか、将来の拡張用に残すかを決定する必要があります。
+
+## 推奨アクション
+
+1. **案1を採用**：必要最小限のタイル種類のみ残す
+2. TileType enumを修正
+3. GetTileTypeName()メソッドを更新
+4. 既存のコードでTileType.Houseを使用している箇所を確認・修正


### PR DESCRIPTION
Refactor `TileType` enum to include specific house types and remove unused tile types as per user request.

The original `TileType.House` was too generic, preventing differentiation by material (wood, brick, stone). This PR introduces `WoodenHouse`, `BrickHouse`, and `StoneHouse` types, and removes `Forest`, `Mountain`, `River`, and `Special` types which were not required, simplifying the game's tile system.