### PR TITLE
Define initial action space effects

### DIFF
--- a/WorkerPlacementCardGame/Assets/Scripts/GameBoard/AccumulationSystem.cs
+++ b/WorkerPlacementCardGame/Assets/Scripts/GameBoard/AccumulationSystem.cs
@@ -259,6 +259,11 @@ public class ActionEffect
                 }
                 break;
                 
+            case ActionEffectType.PlayMinorImprovement:
+                // 小さい進歩カードプレイ（別のスクリプトで実装予定）
+                PlayMinorImprovementCard(player, amount);
+                break;
+                
             default:
                 Debug.LogWarning($"[ActionEffect] Unknown effect type: {effectType}");
                 break;
@@ -287,6 +292,32 @@ public class ActionEffect
                 
             default:
                 return true;
+        }
+    }
+    
+    /// <summary>
+    /// 小さい進歩カードをプレイする処理
+    /// </summary>
+    /// <param name="player">対象プレイヤー</param>
+    /// <param name="amount">プレイできるカード数</param>
+    private void PlayMinorImprovementCard(Player player, int amount)
+    {
+        // 別のスクリプトで実装予定の進歩カード管理システムを呼び出し
+        var improvementManager = Object.FindObjectOfType<ImprovementManager>();
+        if (improvementManager != null)
+        {
+            improvementManager.PlayMinorImprovement(player, amount);
+        }
+        else
+        {
+            // プレースホルダー処理：ImprovementManagerが未実装の場合
+            Debug.Log($"[ActionEffect] {player.playerName}が小さい進歩カードを{amount}枚プレイできます（ImprovementManager未実装）");
+            
+            // 仮実装：プレイヤーのOnMinorImprovementPlayableイベントを発火
+            if (player != null)
+            {
+                player.OnMinorImprovementPlayable?.Invoke(amount);
+            }
         }
     }
     
@@ -327,6 +358,7 @@ public enum ActionEffectType
     TakeAnimals,        // 動物獲得
     PlayOccupation,     // 職業カードプレイ
     PlayImprovement,    // 改良カードプレイ
+    PlayMinorImprovement, // 小さい進歩カードプレイ
     StartingPlayer,     // スタートプレイヤー
     TradeResources,     // リソース交換
     SpecialAction       // 特殊アクション

--- a/WorkerPlacementCardGame/Assets/Scripts/GameBoard/AccumulationSystem.cs
+++ b/WorkerPlacementCardGame/Assets/Scripts/GameBoard/AccumulationSystem.cs
@@ -264,6 +264,11 @@ public class ActionEffect
                 PlayMinorImprovementCard(player, amount);
                 break;
                 
+            case ActionEffectType.PlayOccupation:
+                // 職業カードプレイ（別のスクリプトで実装予定）
+                PlayOccupationCard(player, amount);
+                break;
+                
             default:
                 Debug.LogWarning($"[ActionEffect] Unknown effect type: {effectType}");
                 break;
@@ -317,6 +322,32 @@ public class ActionEffect
             if (player != null)
             {
                 player.OnMinorImprovementPlayable?.Invoke(amount);
+            }
+        }
+    }
+    
+    /// <summary>
+    /// 職業カードをプレイする処理
+    /// </summary>
+    /// <param name="player">対象プレイヤー</param>
+    /// <param name="amount">プレイできるカード数</param>
+    private void PlayOccupationCard(Player player, int amount)
+    {
+        // 別のスクリプトで実装予定の職業カード管理システムを呼び出し
+        var occupationManager = Object.FindObjectOfType<OccupationManager>();
+        if (occupationManager != null)
+        {
+            occupationManager.PlayOccupation(player, amount);
+        }
+        else
+        {
+            // プレースホルダー処理：OccupationManagerが未実装の場合
+            Debug.Log($"[ActionEffect] {player.playerName}が職業カードを{amount}枚プレイできます（OccupationManager未実装）");
+            
+            // 仮実装：プレイヤーのOnOccupationPlayableイベントを発火
+            if (player != null)
+            {
+                player.OnOccupationPlayable?.Invoke(amount);
             }
         }
     }

--- a/WorkerPlacementCardGame/Assets/Scripts/Managers/ActionSpaceManager.cs
+++ b/WorkerPlacementCardGame/Assets/Scripts/Managers/ActionSpaceManager.cs
@@ -46,7 +46,7 @@ public class ActionSpaceManager : MonoBehaviour
             actionSpaceNames = new List<string>
             {
                 "森", "土取り場", "葦の沼", "漁場", "日雇い労働者",
-                "穀物の種", "畑を耕す", "スタートプレイヤー", "住居の拡張"
+                "穀物の種", "畑を耕す", "職業", "スタートプレイヤー", "住居の拡張"
             }
         });
         

--- a/WorkerPlacementCardGame/Assets/Scripts/Managers/ImprovementManager.cs
+++ b/WorkerPlacementCardGame/Assets/Scripts/Managers/ImprovementManager.cs
@@ -1,0 +1,195 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+/// <summary>
+/// 進歩カード（小さい進歩・大きい進歩）を管理するシステム
+/// 現在はプレースホルダー実装
+/// TODO: 将来的に完全な進歩カードシステムを実装予定
+/// </summary>
+public class ImprovementManager : MonoBehaviour
+{
+    [Header("デバッグ設定")]
+    [SerializeField] private bool enableDebugLogs = true;
+    
+    [Header("進歩カード設定")]
+    [SerializeField] private List<MinorImprovementCard> availableMinorImprovements = new List<MinorImprovementCard>();
+    [SerializeField] private List<MajorImprovementCard> availableMajorImprovements = new List<MajorImprovementCard>();
+    
+    // イベント
+    public System.Action<Player, MinorImprovementCard> OnMinorImprovementPlayed;
+    public System.Action<Player, MajorImprovementCard> OnMajorImprovementPlayed;
+    
+    void Start()
+    {
+        InitializeImprovements();
+        DebugLog("ImprovementManager initialized (Placeholder)");
+    }
+    
+    /// <summary>
+    /// 利用可能な改良カードを初期化
+    /// </summary>
+    private void InitializeImprovements()
+    {
+        // TODO: 将来的にここで進歩カードのデータを読み込む
+        DebugLog("Improvement cards initialization - placeholder");
+    }
+    
+    /// <summary>
+    /// 小さい進歩カードをプレイする
+    /// </summary>
+    /// <param name="player">対象プレイヤー</param>
+    /// <param name="count">プレイできるカード数</param>
+    public void PlayMinorImprovement(Player player, int count = 1)
+    {
+        if (player == null)
+        {
+            DebugLog("Player is null in PlayMinorImprovement");
+            return;
+        }
+        
+        // TODO: 将来的に実際の小さい進歩カードの選択・プレイロジックを実装
+        DebugLog($"{player.playerName}が小さい進歩カードを{count}枚プレイできます");
+        
+        // プレースホルダー処理：利用可能な小さい進歩があるかチェック
+        if (availableMinorImprovements.Count == 0)
+        {
+            DebugLog("利用可能な小さい進歩カードがありません（プレースホルダー）");
+            ShowMinorImprovementPlaceholder(player, count);
+            return;
+        }
+        
+        // プレースホルダー処理：簡単なカード選択シミュレーション
+        for (int i = 0; i < count && i < availableMinorImprovements.Count; i++)
+        {
+            var card = availableMinorImprovements[i];
+            DebugLog($"  小さい進歩カード「{card.cardName}」をプレイ可能");
+            
+            // イベント発火
+            OnMinorImprovementPlayed?.Invoke(player, card);
+        }
+    }
+    
+    /// <summary>
+    /// 大きい進歩カードをプレイする
+    /// </summary>
+    /// <param name="player">対象プレイヤー</param>
+    /// <param name="count">プレイできるカード数</param>
+    public void PlayMajorImprovement(Player player, int count = 1)
+    {
+        if (player == null)
+        {
+            DebugLog("Player is null in PlayMajorImprovement");
+            return;
+        }
+        
+        // TODO: 将来的に実際の大きい進歩カードの選択・プレイロジックを実装
+        DebugLog($"{player.playerName}が大きい進歩カードを{count}枚プレイできます");
+        
+        // プレースホルダー処理
+        ShowMajorImprovementPlaceholder(player, count);
+    }
+    
+    /// <summary>
+    /// 小さい進歩カードのプレースホルダー表示
+    /// </summary>
+    private void ShowMinorImprovementPlaceholder(Player player, int count)
+    {
+        DebugLog($"=== 小さい進歩カード選択画面（プレースホルダー） ===");
+        DebugLog($"プレイヤー: {player.playerName}");
+        DebugLog($"選択可能枚数: {count}枚");
+        DebugLog($"※ 実際の進歩カードシステムは未実装です");
+        DebugLog($"※ 将来的にUIでカード選択画面を表示予定");
+        
+        // プレイヤーのイベントを発火して、UIシステムに通知
+        player.OnMinorImprovementPlayable?.Invoke(count);
+    }
+    
+    /// <summary>
+    /// 大きい進歩カードのプレースホルダー表示
+    /// </summary>
+    private void ShowMajorImprovementPlaceholder(Player player, int count)
+    {
+        DebugLog($"=== 大きい進歩カード選択画面（プレースホルダー） ===");
+        DebugLog($"プレイヤー: {player.playerName}");
+        DebugLog($"選択可能枚数: {count}枚");
+        DebugLog($"※ 実際の進歩カードシステムは未実装です");
+    }
+    
+    /// <summary>
+    /// 利用可能な小さい進歩カードを取得
+    /// </summary>
+    public List<MinorImprovementCard> GetAvailableMinorImprovements()
+    {
+        return new List<MinorImprovementCard>(availableMinorImprovements);
+    }
+    
+    /// <summary>
+    /// 利用可能な大きい進歩カードを取得
+    /// </summary>
+    public List<MajorImprovementCard> GetAvailableMajorImprovements()
+    {
+        return new List<MajorImprovementCard>(availableMajorImprovements);
+    }
+    
+    /// <summary>
+    /// デバッグ用：進歩カードシステムの状態を表示
+    /// </summary>
+    [ContextMenu("Show Improvement Status")]
+    public void ShowImprovementStatus()
+    {
+        DebugLog("=== 進歩カードシステム状態 ===");
+        DebugLog($"小さい進歩カード: {availableMinorImprovements.Count}枚");
+        DebugLog($"大きい進歩カード: {availableMajorImprovements.Count}枚");
+        DebugLog($"ステータス: プレースホルダー実装");
+    }
+    
+    private void DebugLog(string message)
+    {
+        if (enableDebugLogs)
+        {
+            Debug.Log($"[ImprovementManager] {message}");
+        }
+    }
+}
+
+/// <summary>
+/// 小さい進歩カードのプレースホルダークラス
+/// TODO: 将来的に完全な進歩カードクラスを実装予定
+/// </summary>
+[System.Serializable]
+public class MinorImprovementCard
+{
+    public string cardName;
+    public string description;
+    public int cost;
+    public ResourceType costType;
+    
+    public MinorImprovementCard(string name, string desc, int cost = 0, ResourceType costType = ResourceType.Wood)
+    {
+        this.cardName = name;
+        this.description = desc;
+        this.cost = cost;
+        this.costType = costType;
+    }
+}
+
+/// <summary>
+/// 大きい進歩カードのプレースホルダークラス
+/// TODO: 将来的に完全な進歩カードクラスを実装予定
+/// </summary>
+[System.Serializable]
+public class MajorImprovementCard
+{
+    public string cardName;
+    public string description;
+    public int cost;
+    public ResourceType costType;
+    
+    public MajorImprovementCard(string name, string desc, int cost = 0, ResourceType costType = ResourceType.Wood)
+    {
+        this.cardName = name;
+        this.description = desc;
+        this.cost = cost;
+        this.costType = costType;
+    }
+}

--- a/WorkerPlacementCardGame/Assets/Scripts/Managers/OccupationManager.cs
+++ b/WorkerPlacementCardGame/Assets/Scripts/Managers/OccupationManager.cs
@@ -1,0 +1,181 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+/// <summary>
+/// 職業カードを管理するシステム
+/// 現在はプレースホルダー実装
+/// TODO: 将来的に完全な職業カードシステムを実装予定
+/// </summary>
+public class OccupationManager : MonoBehaviour
+{
+    [Header("デバッグ設定")]
+    [SerializeField] private bool enableDebugLogs = true;
+    
+    [Header("職業カード設定")]
+    [SerializeField] private List<OccupationCardData> availableOccupations = new List<OccupationCardData>();
+    
+    // イベント
+    public System.Action<Player, OccupationCardData> OnOccupationPlayed;
+    
+    void Start()
+    {
+        InitializeOccupations();
+        DebugLog("OccupationManager initialized (Placeholder)");
+    }
+    
+    /// <summary>
+    /// 利用可能な職業カードを初期化
+    /// </summary>
+    private void InitializeOccupations()
+    {
+        // TODO: 将来的にここで職業カードのデータを読み込む
+        // プレースホルダーとしていくつかの職業を追加
+        availableOccupations.Add(new OccupationCardData("農夫", "畑での作業時に追加ボーナスを得る"));
+        availableOccupations.Add(new OccupationCardData("大工", "建設アクション時にコストを削減"));
+        availableOccupations.Add(new OccupationCardData("パン屋", "穀物を食料に変換できる"));
+        availableOccupations.Add(new OccupationCardData("牧場主", "動物の世話で追加効果を得る"));
+        availableOccupations.Add(new OccupationCardData("商人", "リソース交換で有利なレートを得る"));
+        
+        DebugLog($"Occupation cards initialized: {availableOccupations.Count} cards");
+    }
+    
+    /// <summary>
+    /// 職業カードをプレイする
+    /// </summary>
+    /// <param name="player">対象プレイヤー</param>
+    /// <param name="count">プレイできるカード数</param>
+    public void PlayOccupation(Player player, int count = 1)
+    {
+        if (player == null)
+        {
+            DebugLog("Player is null in PlayOccupation");
+            return;
+        }
+        
+        // TODO: 将来的に実際の職業カードの選択・プレイロジックを実装
+        DebugLog($"{player.playerName}が職業カードを{count}枚プレイできます");
+        
+        // プレースホルダー処理：利用可能な職業があるかチェック
+        if (availableOccupations.Count == 0)
+        {
+            DebugLog("利用可能な職業カードがありません（プレースホルダー）");
+            ShowOccupationPlaceholder(player, count);
+            return;
+        }
+        
+        // プレースホルダー処理：簡単なカード選択シミュレーション
+        for (int i = 0; i < count && i < availableOccupations.Count; i++)
+        {
+            var card = availableOccupations[i];
+            DebugLog($"  職業カード「{card.cardName}」をプレイ可能");
+            
+            // イベント発火
+            OnOccupationPlayed?.Invoke(player, card);
+        }
+    }
+    
+    /// <summary>
+    /// 職業カードのプレースホルダー表示
+    /// </summary>
+    private void ShowOccupationPlaceholder(Player player, int count)
+    {
+        DebugLog($"=== 職業カード選択画面（プレースホルダー） ===");
+        DebugLog($"プレイヤー: {player.playerName}");
+        DebugLog($"選択可能枚数: {count}枚");
+        DebugLog($"※ 実際の職業カードシステムは未実装です");
+        DebugLog($"※ 将来的にUIでカード選択画面を表示予定");
+        
+        // 利用可能な職業カードをリスト表示
+        DebugLog("利用可能な職業カード:");
+        for (int i = 0; i < availableOccupations.Count && i < count; i++)
+        {
+            var card = availableOccupations[i];
+            DebugLog($"  {i + 1}. {card.cardName} - {card.description}");
+        }
+        
+        // プレイヤーのイベントを発火して、UIシステムに通知
+        player.OnOccupationPlayable?.Invoke(count);
+    }
+    
+    /// <summary>
+    /// 利用可能な職業カードを取得
+    /// </summary>
+    public List<OccupationCardData> GetAvailableOccupations()
+    {
+        return new List<OccupationCardData>(availableOccupations);
+    }
+    
+    /// <summary>
+    /// 特定の職業カードをプレイヤーに追加（テスト用）
+    /// </summary>
+    public bool AddOccupationToPlayer(Player player, string occupationName)
+    {
+        var occupation = availableOccupations.Find(o => o.cardName == occupationName);
+        if (occupation != null)
+        {
+            DebugLog($"{player.playerName}が職業「{occupationName}」を獲得しました");
+            OnOccupationPlayed?.Invoke(player, occupation);
+            return true;
+        }
+        return false;
+    }
+    
+    /// <summary>
+    /// デバッグ用：職業カードシステムの状態を表示
+    /// </summary>
+    [ContextMenu("Show Occupation Status")]
+    public void ShowOccupationStatus()
+    {
+        DebugLog("=== 職業カードシステム状態 ===");
+        DebugLog($"利用可能な職業カード: {availableOccupations.Count}枚");
+        DebugLog($"ステータス: プレースホルダー実装");
+        
+        DebugLog("職業カードリスト:");
+        foreach (var occupation in availableOccupations)
+        {
+            DebugLog($"  - {occupation.cardName}: {occupation.description}");
+        }
+    }
+    
+    private void DebugLog(string message)
+    {
+        if (enableDebugLogs)
+        {
+            Debug.Log($"[OccupationManager] {message}");
+        }
+    }
+}
+
+/// <summary>
+/// 職業カードのプレースホルダークラス
+/// TODO: 将来的に完全な職業カードクラスを実装予定
+/// </summary>
+[System.Serializable]
+public class OccupationCardData
+{
+    public string cardName;
+    public string description;
+    public OccupationType occupationType;
+    public bool isActive;
+    
+    public OccupationCardData(string name, string desc, OccupationType type = OccupationType.General)
+    {
+        this.cardName = name;
+        this.description = desc;
+        this.occupationType = type;
+        this.isActive = false;
+    }
+}
+
+/// <summary>
+/// 職業の種類
+/// </summary>
+public enum OccupationType
+{
+    General,        // 一般職業
+    Farmer,         // 農業関連
+    Builder,        // 建設関連
+    Trader,         // 商業関連
+    Artisan,        // 手工業関連
+    Cook            // 料理関連
+}

--- a/WorkerPlacementCardGame/Assets/Scripts/Managers/Player.cs
+++ b/WorkerPlacementCardGame/Assets/Scripts/Managers/Player.cs
@@ -122,6 +122,7 @@ public class Player : MonoBehaviour
     public System.Action<ResourceType, int> OnResourceChanged;
     public System.Action<int> OnVictoryPointsChanged;
     public System.Action<Card> OnCardPlayed;
+    public System.Action<int> OnMinorImprovementPlayable;
     
     [Header("タイル管理")]
     [SerializeField] private TileManager tileManager; // TileManagerの参照

--- a/WorkerPlacementCardGame/Assets/Scripts/Managers/Player.cs
+++ b/WorkerPlacementCardGame/Assets/Scripts/Managers/Player.cs
@@ -123,6 +123,7 @@ public class Player : MonoBehaviour
     public System.Action<int> OnVictoryPointsChanged;
     public System.Action<Card> OnCardPlayed;
     public System.Action<int> OnMinorImprovementPlayable;
+    public System.Action<int> OnOccupationPlayable;
     
     [Header("タイル管理")]
     [SerializeField] private TileManager tileManager; // TileManagerの参照

--- a/初期アクションスペース効果定義.md
+++ b/初期アクションスペース効果定義.md
@@ -170,14 +170,14 @@ actionType: ActionType.AddField
 **固有効果**:
 ```csharp
 coreEffects: [
-    new ActionEffect(ActionEffectType.GainResource, ResourceType.Food, 1)
+    new ActionEffect(ActionEffectType.PlayMinorImprovement, ResourceType.None, 1)
 ]
 actionType: ActionType.StartingPlayer
 ```
 
 **効果説明**:
 - 累積効果なし（毎ラウンド同じ効果）
-- プレイヤーがワーカーを配置すると、食料1個を獲得
+- プレイヤーがワーカーを配置すると、小さい進歩カードを1枚プレイできる
 - 次のラウンドのスタートプレイヤーになる
 
 ### 9. 住居の拡張 (house_expansion)
@@ -245,6 +245,17 @@ public void SetupPlowField()
     coreEffects.Add(new ActionEffect(ActionEffectType.AddField, ResourceType.None, 1));
 }
 
+// スタートプレイヤーの設定例
+public void SetupStartingPlayer()
+{
+    actionId = "starting_player";
+    actionName = "スタートプレイヤー";
+    actionType = ActionType.StartingPlayer;
+    
+    coreEffects.Clear();
+    coreEffects.Add(new ActionEffect(ActionEffectType.PlayMinorImprovement, ResourceType.None, 1));
+}
+
 // 住居の拡張の設定例
 public void SetupHouseExpansion()
 {
@@ -271,7 +282,7 @@ public void SetupHouseExpansion()
 - **日雇い労働者**: 食料2個（安定した食料源）
 - **穀物の種**: 穀物1個（農業の基礎）
 - **畑を耕す**: 畑1個追加（農業の基礎）
-- **スタートプレイヤー**: 食料1個 + 手番順変更
+- **スタートプレイヤー**: 小さい進歩カード1枚プレイ + 手番順変更
 - **住居の拡張**: 木材5個 + 葦2個消費で部屋1個追加
 
 ## 📊 バランス分析
@@ -285,6 +296,7 @@ public void SetupHouseExpansion()
 - **森**: 建設に必要な木材の主要供給源
 - **日雇い労働者**: 食料不足時の緊急手段
 - **畑を耕す**: 長期的な食料生産の基盤
+- **スタートプレイヤー**: 小さい進歩カードプレイ + 手番順優位性
 - **住居の拡張**: 家族増加の前提条件
 
 ## 🔄 今後の拡張
@@ -314,3 +326,35 @@ public void SetupHouseExpansion()
 - [ ] デバッグ用の効果確認システム
 
 この定義により、初期アクションスペースの効果が明確になり、バランスの取れたゲーム体験が実現できます。
+
+## 🔄 最新の変更内容
+
+### 2024年12月 - スタートプレイヤーアクション更新
+
+**変更内容**:
+- **削除**: 食料1個獲得効果
+- **追加**: 小さい進歩カード1枚プレイ効果
+
+**理由**: 
+- スタートプレイヤーアクションが強くなりすぎることを防ぐため
+- より戦略的な選択肢を提供するため
+
+**実装詳細**:
+```csharp
+// 新しいスタートプレイヤーの設定
+actionId = "starting_player";
+actionType = ActionType.StartingPlayer;
+coreEffects = [
+    new ActionEffect(ActionEffectType.PlayMinorImprovement, ResourceType.None, 1)
+];
+```
+
+**関連システム**:
+- `ImprovementManager`: 進歩カード管理システム（プレースホルダー実装）
+- `Player.OnMinorImprovementPlayable`: 小さい進歩カードプレイ可能イベント
+- `ActionEffectType.PlayMinorImprovement`: 新しい効果タイプ
+
+**今後の実装予定**:
+- 完全な進歩カードシステムの実装
+- UIでの進歩カード選択画面
+- 進歩カードの効果システム

--- a/初期アクションスペース効果定義.md
+++ b/初期アクションスペース効果定義.md
@@ -1,0 +1,316 @@
+# 初期アクションスペース効果定義
+
+## 📋 概要
+
+このドキュメントは、Agricola風ワーカープレイスメントゲームにおける **初期アクションスペース**（ラウンド1から利用可能）の効果を具体的に定義します。
+
+現在実装されている **分離システム** に基づいて、以下の2つの効果に分けて定義します：
+
+1. **累積効果** - `AccumulatedItemManager`が管理する毎ラウンド自動累積
+2. **固有効果** - `ActionEffect`システムが管理するアクションスペース独自の効果
+
+## 🎯 初期アクションスペース一覧
+
+### フェーズ1（ラウンド1から利用可能）
+- 森
+- 土取り場
+- 葦の沼
+- 漁場
+- 日雇い労働者
+- 穀物の種
+- 畑を耕す
+- スタートプレイヤー
+- 住居の拡張
+
+## 🔧 詳細効果定義
+
+### 1. 森 (forest)
+
+**アクションスペースID**: `forest`
+
+**累積効果**:
+```csharp
+AccumulationRule("forest", ResourceType.Wood, 3, "森：木材3個/ラウンド")
+```
+
+**固有効果**:
+```csharp
+coreEffects: なし
+```
+
+**効果説明**:
+- 毎ラウンド開始時に木材3個が自動で累積される
+- プレイヤーがワーカーを配置すると、累積された木材を全て獲得
+- 累積量は使用されなかった分が次のラウンドに持ち越される
+
+### 2. 土取り場 (clay_pit)
+
+**アクションスペースID**: `clay_pit`
+
+**累積効果**:
+```csharp
+AccumulationRule("clay_pit", ResourceType.Clay, 1, "土取り場：土1個/ラウンド")
+```
+
+**固有効果**:
+```csharp
+coreEffects: なし
+```
+
+**効果説明**:
+- 毎ラウンド開始時に土1個が自動で累積される
+- プレイヤーがワーカーを配置すると、累積された土を全て獲得
+
+### 3. 葦の沼 (reed_pond)
+
+**アクションスペースID**: `reed_pond`
+
+**累積効果**:
+```csharp
+AccumulationRule("reed_pond", ResourceType.Reed, 1, "葦の沼：葦1個/ラウンド")
+```
+
+**固有効果**:
+```csharp
+coreEffects: なし
+```
+
+**効果説明**:
+- 毎ラウンド開始時に葦1個が自動で累積される
+- プレイヤーがワーカーを配置すると、累積された葦を全て獲得
+
+### 4. 漁場 (fishing)
+
+**アクションスペースID**: `fishing`
+
+**累積効果**:
+```csharp
+AccumulationRule("fishing", ResourceType.Food, 1, "漁場：食料1個/ラウンド")
+```
+
+**固有効果**:
+```csharp
+coreEffects: なし
+```
+
+**効果説明**:
+- 毎ラウンド開始時に食料1個が自動で累積される
+- プレイヤーがワーカーを配置すると、累積された食料を全て獲得
+
+### 5. 日雇い労働者 (day_laborer)
+
+**アクションスペースID**: `day_laborer`
+
+**累積効果**:
+```csharp
+累積なし
+```
+
+**固有効果**:
+```csharp
+coreEffects: [
+    new ActionEffect(ActionEffectType.GainResource, ResourceType.Food, 2)
+]
+```
+
+**効果説明**:
+- 累積効果なし（毎ラウンド同じ効果）
+- プレイヤーがワーカーを配置すると、即座に食料2個を獲得
+
+### 6. 穀物の種 (grain_seeds)
+
+**アクションスペースID**: `grain_seeds`
+
+**累積効果**:
+```csharp
+累積なし
+```
+
+**固有効果**:
+```csharp
+coreEffects: [
+    new ActionEffect(ActionEffectType.GainResource, ResourceType.Grain, 1)
+]
+```
+
+**効果説明**:
+- 累積効果なし（毎ラウンド同じ効果）
+- プレイヤーがワーカーを配置すると、即座に穀物1個を獲得
+
+### 7. 畑を耕す (plow_field)
+
+**アクションスペースID**: `plow_field`
+
+**累積効果**:
+```csharp
+累積なし
+```
+
+**固有効果**:
+```csharp
+coreEffects: [
+    new ActionEffect(ActionEffectType.AddField, ResourceType.None, 1)
+]
+actionType: ActionType.AddField
+```
+
+**効果説明**:
+- 累積効果なし（毎ラウンド同じ効果）
+- プレイヤーがワーカーを配置すると、即座に畑1個を追加
+
+### 8. スタートプレイヤー (starting_player)
+
+**アクションスペースID**: `starting_player`
+
+**累積効果**:
+```csharp
+累積なし
+```
+
+**固有効果**:
+```csharp
+coreEffects: [
+    new ActionEffect(ActionEffectType.GainResource, ResourceType.Food, 1)
+]
+actionType: ActionType.StartingPlayer
+```
+
+**効果説明**:
+- 累積効果なし（毎ラウンド同じ効果）
+- プレイヤーがワーカーを配置すると、食料1個を獲得
+- 次のラウンドのスタートプレイヤーになる
+
+### 9. 住居の拡張 (house_expansion)
+
+**アクションスペースID**: `house_expansion`
+
+**累積効果**:
+```csharp
+累積なし
+```
+
+**固有効果**:
+```csharp
+coreEffects: [
+    new ActionEffect(ActionEffectType.SpendResource, ResourceType.Wood, 5),
+    new ActionEffect(ActionEffectType.SpendResource, ResourceType.Reed, 2),
+    new ActionEffect(ActionEffectType.HouseExpansion, ResourceType.None, 1)
+]
+actionType: ActionType.HouseExpansion
+```
+
+**効果説明**:
+- 累積効果なし（毎ラウンド同じ効果）
+- プレイヤーがワーカーを配置すると、木材5個と葦2個を消費して住居を1部屋拡張
+
+## 🔄 実装コード例
+
+### ActionSpaceManagerでの累積ルール設定
+
+```csharp
+private void InitializeStandardRules()
+{
+    standardRules.Clear();
+    
+    // 累積効果のあるアクションスペース
+    standardRules.Add(new AccumulationRule("forest", ResourceType.Wood, 3, "森：木材3個/ラウンド"));
+    standardRules.Add(new AccumulationRule("clay_pit", ResourceType.Clay, 1, "土取り場：土1個/ラウンド"));
+    standardRules.Add(new AccumulationRule("reed_pond", ResourceType.Reed, 1, "葦の沼：葦1個/ラウンド"));
+    standardRules.Add(new AccumulationRule("fishing", ResourceType.Food, 1, "漁場：食料1個/ラウンド"));
+}
+```
+
+### ActionSpaceでの固有効果設定例
+
+```csharp
+// 日雇い労働者の設定例
+public void SetupDayLaborer()
+{
+    actionId = "day_laborer";
+    actionName = "日雇い労働者";
+    actionType = ActionType.GainResources;
+    
+    coreEffects.Clear();
+    coreEffects.Add(new ActionEffect(ActionEffectType.GainResource, ResourceType.Food, 2));
+}
+
+// 畑を耕すの設定例
+public void SetupPlowField()
+{
+    actionId = "plow_field";
+    actionName = "畑を耕す";
+    actionType = ActionType.AddField;
+    
+    coreEffects.Clear();
+    coreEffects.Add(new ActionEffect(ActionEffectType.AddField, ResourceType.None, 1));
+}
+
+// 住居の拡張の設定例
+public void SetupHouseExpansion()
+{
+    actionId = "house_expansion";
+    actionName = "住居の拡張";
+    actionType = ActionType.HouseExpansion;
+    
+    coreEffects.Clear();
+    coreEffects.Add(new ActionEffect(ActionEffectType.SpendResource, ResourceType.Wood, 5));
+    coreEffects.Add(new ActionEffect(ActionEffectType.SpendResource, ResourceType.Reed, 2));
+    coreEffects.Add(new ActionEffect(ActionEffectType.HouseExpansion, ResourceType.None, 1));
+}
+```
+
+## 🎯 効果の特徴
+
+### 累積効果のあるアクションスペース
+- **森**: 木材3個/ラウンド（最も価値の高い累積）
+- **土取り場**: 土1個/ラウンド
+- **葦の沼**: 葦1個/ラウンド
+- **漁場**: 食料1個/ラウンド
+
+### 固有効果のみのアクションスペース
+- **日雇い労働者**: 食料2個（安定した食料源）
+- **穀物の種**: 穀物1個（農業の基礎）
+- **畑を耕す**: 畑1個追加（農業の基礎）
+- **スタートプレイヤー**: 食料1個 + 手番順変更
+- **住居の拡張**: 木材5個 + 葦2個消費で部屋1個追加
+
+## 📊 バランス分析
+
+### リソース獲得効率
+1. **森**: 木材3個/ラウンド（最高効率）
+2. **日雇い労働者**: 食料2個/ラウンド（安定効率）
+3. **土取り場・葦の沼・漁場**: 各1個/ラウンド（標準効率）
+
+### 戦略的価値
+- **森**: 建設に必要な木材の主要供給源
+- **日雇い労働者**: 食料不足時の緊急手段
+- **畑を耕す**: 長期的な食料生産の基盤
+- **住居の拡張**: 家族増加の前提条件
+
+## 🔄 今後の拡張
+
+### 第2段階（ラウンド2以降）
+- **柵の建設**: 木材消費で柵建設
+- **羊市場**: 羊1匹/ラウンド累積
+
+### 第3段階（ラウンド3以降）
+- **種まきと製パン**: 種まき + 食料変換
+
+### 第4段階（ラウンド5以降）
+- **家族の成長**: 家族メンバー追加
+
+## 📝 実装チェックリスト
+
+### 必須実装
+- [x] AccumulatedItemManager での累積ルール設定
+- [x] ActionEffect システムでの固有効果設定
+- [x] ActionSpace での効果実行システム
+- [x] ActionSpaceManager での段階的解放システム
+
+### 推奨実装
+- [ ] UI での累積アイテム表示
+- [ ] 効果のアニメーション
+- [ ] 効果の詳細説明表示
+- [ ] デバッグ用の効果確認システム
+
+この定義により、初期アクションスペースの効果が明確になり、バランスの取れたゲーム体験が実現できます。

--- a/初期アクションスペース効果定義.md
+++ b/初期アクションスペース効果定義.md
@@ -19,6 +19,7 @@
 - 日雇い労働者
 - 穀物の種
 - 畑を耕す
+- 職業
 - スタートプレイヤー
 - 住居の拡張
 
@@ -158,7 +159,29 @@ actionType: ActionType.AddField
 - 累積効果なし（毎ラウンド同じ効果）
 - プレイヤーがワーカーを配置すると、即座に畑1個を追加
 
-### 8. スタートプレイヤー (starting_player)
+### 8. 職業 (occupation)
+
+**アクションスペースID**: `occupation`
+
+**累積効果**:
+```csharp
+累積なし
+```
+
+**固有効果**:
+```csharp
+coreEffects: [
+    new ActionEffect(ActionEffectType.PlayOccupation, ResourceType.None, 1)
+]
+actionType: ActionType.PlayOccupation
+```
+
+**効果説明**:
+- 累積効果なし（毎ラウンド同じ効果）
+- プレイヤーがワーカーを配置すると、職業カードを1枚プレイできる
+- 職業カードは永続的な効果を持つ特殊カード
+
+### 9. スタートプレイヤー (starting_player)
 
 **アクションスペースID**: `starting_player`
 
@@ -180,7 +203,7 @@ actionType: ActionType.StartingPlayer
 - プレイヤーがワーカーを配置すると、小さい進歩カードを1枚プレイできる
 - 次のラウンドのスタートプレイヤーになる
 
-### 9. 住居の拡張 (house_expansion)
+### 10. 住居の拡張 (house_expansion)
 
 **アクションスペースID**: `house_expansion`
 
@@ -245,6 +268,17 @@ public void SetupPlowField()
     coreEffects.Add(new ActionEffect(ActionEffectType.AddField, ResourceType.None, 1));
 }
 
+// 職業の設定例
+public void SetupOccupation()
+{
+    actionId = "occupation";
+    actionName = "職業";
+    actionType = ActionType.PlayOccupation;
+    
+    coreEffects.Clear();
+    coreEffects.Add(new ActionEffect(ActionEffectType.PlayOccupation, ResourceType.None, 1));
+}
+
 // スタートプレイヤーの設定例
 public void SetupStartingPlayer()
 {
@@ -282,6 +316,7 @@ public void SetupHouseExpansion()
 - **日雇い労働者**: 食料2個（安定した食料源）
 - **穀物の種**: 穀物1個（農業の基礎）
 - **畑を耕す**: 畑1個追加（農業の基礎）
+- **職業**: 職業カード1枚プレイ（永続効果の獲得）
 - **スタートプレイヤー**: 小さい進歩カード1枚プレイ + 手番順変更
 - **住居の拡張**: 木材5個 + 葦2個消費で部屋1個追加
 
@@ -296,6 +331,7 @@ public void SetupHouseExpansion()
 - **森**: 建設に必要な木材の主要供給源
 - **日雇い労働者**: 食料不足時の緊急手段
 - **畑を耕す**: 長期的な食料生産の基盤
+- **職業**: 永続的な特殊能力の獲得
 - **スタートプレイヤー**: 小さい進歩カードプレイ + 手番順優位性
 - **住居の拡張**: 家族増加の前提条件
 
@@ -329,7 +365,9 @@ public void SetupHouseExpansion()
 
 ## 🔄 最新の変更内容
 
-### 2024年12月 - スタートプレイヤーアクション更新
+### 2024年12月 - 初期アクションスペース拡張
+
+#### 1. スタートプレイヤーアクション更新
 
 **変更内容**:
 - **削除**: 食料1個獲得効果
@@ -339,22 +377,37 @@ public void SetupHouseExpansion()
 - スタートプレイヤーアクションが強くなりすぎることを防ぐため
 - より戦略的な選択肢を提供するため
 
+#### 2. 職業アクションスペース追加
+
+**追加内容**:
+- **新アクションスペース**: 「職業」
+- **効果**: 職業カード1枚プレイ
+- **位置**: 初期アクションスペース（ラウンド1から利用可能）
+
 **実装詳細**:
 ```csharp
-// 新しいスタートプレイヤーの設定
-actionId = "starting_player";
-actionType = ActionType.StartingPlayer;
+// 職業アクションスペースの設定
+actionId = "occupation";
+actionType = ActionType.PlayOccupation;
 coreEffects = [
-    new ActionEffect(ActionEffectType.PlayMinorImprovement, ResourceType.None, 1)
+    new ActionEffect(ActionEffectType.PlayOccupation, ResourceType.None, 1)
 ];
 ```
 
 **関連システム**:
-- `ImprovementManager`: 進歩カード管理システム（プレースホルダー実装）
-- `Player.OnMinorImprovementPlayable`: 小さい進歩カードプレイ可能イベント
-- `ActionEffectType.PlayMinorImprovement`: 新しい効果タイプ
+- `OccupationManager`: 職業カード管理システム（プレースホルダー実装）
+- `Player.OnOccupationPlayable`: 職業カードプレイ可能イベント
+- `ActionEffectType.PlayOccupation`: 既存の効果タイプを活用
+
+**利用可能な職業例**（プレースホルダー）:
+- 農夫: 畑での作業時に追加ボーナス
+- 大工: 建設アクション時にコスト削減
+- パン屋: 穀物を食料に変換
+- 牧場主: 動物の世話で追加効果
+- 商人: リソース交換で有利なレート
 
 **今後の実装予定**:
-- 完全な進歩カードシステムの実装
-- UIでの進歩カード選択画面
-- 進歩カードの効果システム
+- 完全な職業カードシステムの実装
+- 職業カードの永続効果システム
+- UIでの職業カード選択画面
+- 職業カードの効果システム


### PR DESCRIPTION
Adjust 'Start Player' action and add 'Occupation' action space to enhance strategic depth and balance initial gameplay.

This PR includes placeholder implementations for the card systems, laying the groundwork for future full feature development.